### PR TITLE
adds buttons to each article on a rep page that can be used to submit a ...

### DIFF
--- a/app/assets/javascripts/reps.js
+++ b/app/assets/javascripts/reps.js
@@ -147,16 +147,18 @@ function togglePledgeButtons(visible) {
 
 function pledgeButtonSetup() {
   //adds event listeners to pledge buttons
-  $('#positive-pledge').on('click', function(){
+  $(document).on('click', '#positive-pledge', function(){
     togglePledgeButtons(false);
     $("#tweet-box").data('positive', 'true')
     $('.pledge-form-wrapper').show()
+    sessionStorage.currentArticleId = $(this).parent().data('article-id');
   })
 
-  $('#negative-pledge').on('click', function(){
+  $(document).on('click', '#negative-pledge', function(){
     togglePledgeButtons(false);
     $("#tweet-box").data('positive', 'false')
     $('.pledge-form-wrapper').show()
+    sessionStorage.currentArticleId = $(this).parent().data('article-id');
   })
 
   $("#close-tweet-button").on('click', function() {
@@ -179,7 +181,8 @@ function pledgeFormSubmit() {
       return;
     }
     var msg = $("#tweet-handle").text();
-    makeTweet($('#tweet-box').val());
+    var articleId = sessionStorage.currentArticleId
+    makeTweet($('#tweet-box').val(), articleId);
     updateFulfillMeter($("#tweet-box").data().positive);
     //makeTweet(handle + $("#tweet-box").val() + " #WeThePAC")
 

--- a/app/assets/javascripts/tweet.js
+++ b/app/assets/javascripts/tweet.js
@@ -1,15 +1,15 @@
-function makeTweet(newMessage) {
+function makeTweet(newMessage, articleId) {
   var tweet = $.ajax({ url: "/api/tweets",
     type: 'POST',
     beforeSend: function(xhr) {xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content'))},
     data: {tweet: {message: newMessage}},
     success: function(response) {
-      postPledge(response.tweet_id, newMessage);
+      postPledge(response.tweet_id, newMessage, articleId);
     }
   });
 }
 
-function postPledge(tweetId, newMessage) {
+function postPledge(tweetId, newMessage, articleId) {
   var positive = $('#tweet-box').data('positive')
 
   // regexp to get any number of digits (#) starting from end ($) of path name
@@ -19,7 +19,7 @@ function postPledge(tweetId, newMessage) {
     type: 'POST',
     dataType: 'json',
     beforeSend: function(xhr) {xhr.setRequestHeader('X-CSRF-Token', $('meta[name="csrf-token"]').attr('content'))},
-    data: {tweet_id: tweetId, rep_id: repId, positive: positive, tweet_message: newMessage}
+    data: {tweet_id: tweetId, rep_id: repId, positive: positive, tweet_message: newMessage, articleId: articleId}
   })
   .done(function() {
     console.log("successfully posted pledge");

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -33,7 +33,7 @@ class ApiController < ApplicationController
     puts "="*100
     puts params
     rep = Rep.find(params[:rep_id])
-    pledge = Pledge.create(tweet_id: params[:tweet_id], rep_id: rep.id, user_id: current_user.id, user_twitter_handle: current_user.twitter_handle, user_thumbnail_url: current_user.profile_pic_thumb_url, rep_twitter_handle: rep.twitter_handle, positive: params[:positive], tweet_message: params[:tweet_message], rep_thumbnail_url: rep.thumbnail_url, user_name: current_user.name, rep_name: rep.name, rep_external_url: rep.external_url)
+    pledge = Pledge.create(tweet_id: params[:tweet_id], rep_id: rep.id, user_id: current_user.id, user_twitter_handle: current_user.twitter_handle, user_thumbnail_url: current_user.profile_pic_thumb_url, rep_twitter_handle: rep.twitter_handle, positive: params[:positive], tweet_message: params[:tweet_message], rep_thumbnail_url: rep.thumbnail_url, user_name: current_user.name, rep_name: rep.name, rep_external_url: rep.external_url, article_id: params[:articleId])
 
     firebase = Firebase::Client.new("https://we-the-pac.firebaseio.com/#{rep.id}", ENV['FIREBASE_SECRET'])
     response = firebase.set('pledge', pledge)

--- a/app/views/reps/show.html.erb
+++ b/app/views/reps/show.html.erb
@@ -36,12 +36,6 @@
 {{rep.name}} <a class="profile_handle" href="http://twitter.com/{{rep.twitter_handle}}">@{{rep.twitter_handle}}</a>
 </p>
 
-
-<% if current_user %>
-<button id="positive-pledge">pledge for</button>
-<button id="negative-pledge">pledge against</button>
-<% end %>
-
 <% positive_percent = (@rep.pledges.where(positive: true).count.to_f/@rep.pledges.count.to_f)*100 %>
 
 <div id='meter_wrapper'>
@@ -124,11 +118,15 @@ function updateFulfillMeter(positive) {
 
 
 <script type="text/x-handlebars-template" id="midFeedListTemplate">
-<li class="feedListItem" data-id={{data.id}} data-open="false">
+<li class="feedListItem" data-id={{data.id}} data-open="false" data-article-id={{data.id}}>
 <p class="feedListItemTitle">{{data.title}}</p>
 <p class="feedListItemExcerpt">{{data.excerpt}}...
 <a href="{{data.url}}" class="feedListItemLink">more</a>
 </p>
+<% if current_user %>
+<button id="positive-pledge">pledge for</button>
+<button id="negative-pledge">pledge against</button>
+<% end %>
 </li>
 </script>
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20150310175305) do
     t.text     "url"
     t.string   "title"
     t.text     "excerpt"
+    t.integer  "rep_id"
     t.datetime "date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
...pledge related to a specific article. reps.js:150 - should listen more specifically than document, reps.js:156 - should listen more specifically than document, reps.js:182 - because the form is universal for all pledges, it is not scoped. feel free to pass articleId more securely than via sessionStorage
