### PR TITLE
removed article title and excerpt validations from model, added validation to each rep when fetching articles

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,5 +1,4 @@
 class Article < ActiveRecord::Base
-  validates :url, :title, :excerpt, uniqueness: true
 
   has_many :pledges
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -300,6 +300,24 @@ def delete_old_articles(rep, max_article_count = 8)
   end
 end
 
+def create_article_if_unique_to_rep(rep, article)
+  # look through the articles from the rep and check the title and excerpt for uniqueness
+  matches = 0
+  rep.articles.each do |existing_article|
+    if existing_article.title == article['title']
+      matches += 1
+    elsif existing_article.excerpt == article['excerpt']
+      matches += 1
+    end
+  end
+
+  # if unique, enter article into db. if not, don't enter
+  if matches == 0
+    artReturn = Article.create(article)
+    ArticlesRep.create(article_id: artReturn.id, rep_id: rep.id)
+  end
+end
+
 def fetchArticles (start_id = -1)
   while true
     index = 0
@@ -315,16 +333,18 @@ def fetchArticles (start_id = -1)
       articles.each do |article|
         puts article
 
-        artReturn = Article.create(article)
-        if artReturn.id == nil
-          # this means that the article already exists in the database
-          # dupId = Article.where(url: article.url)[0].id
-          # ArticlesRep.create(article_id: dupId, rep_id: rep.id)
-        else
-          #   the article does not already exist in the database and it is therefore created
-          ArticlesRep.create(article_id: artReturn.id,
-            rep_id: rep.id)
-        end
+        create_article_if_unique_to_rep(rep, article)
+
+        # don't need below anymore as the article's uniqueness is checked in above method.
+        # if artReturn.id == nil
+        #   # this means that the article already exists in the database
+        #   # dupId = Article.where(url: article.url)[0].id
+        #   # ArticlesRep.create(article_id: dupId, rep_id: rep.id)
+        # else
+        #   #   the article does not already exist in the database and it is therefore created
+        #   ArticlesRep.create(article_id: artReturn.id,
+        #     rep_id: rep.id)
+        # end
 
         index += 1
       end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -302,17 +302,11 @@ end
 
 def create_article_if_unique_to_rep(rep, article)
   # look through the articles from the rep and check the title and excerpt for uniqueness
-  matches = 0
-  rep.articles.each do |existing_article|
-    if existing_article.title == article['title']
-      matches += 1
-    elsif existing_article.excerpt == article['excerpt']
-      matches += 1
-    end
-  end
-
   # if unique, enter article into db. if not, don't enter
-  if matches == 0
+    if rep.articles.exists?(title: article['title']) || rep.articles.exists?(excerpt: article['excerpt'])
+      puts 'Duplicate Rep Article! Article not saved...'
+    else
+    puts 'CREATING NEW REP ARTICLE!'
     artReturn = Article.create(article)
     ArticlesRep.create(article_id: artReturn.id, rep_id: rep.id)
   end


### PR DESCRIPTION
Our current validation for checking for duplicate articles is not quite right. We actually, do want duplicates in the database, but don't want duplicates for a single Rep. For example, let's assume an article has two Reps named in it. The first time we scrape this article from google, for Rep A, we want to enter it in the database. The next time we scrape this article, for Rep B, we also want to enter it in the database (of course, specific to Rep B). That way, the article shows up under both Reps. If we come across this article again when we loop back to Rep A, it will not be unique anymore for Rep A, and we don't want it entered into the database. Does this make sense?

So, I this pull request removes the duplicate article validations we had in the model (because we actually do want duplicates) and adds a method called create_article_if_unique_to_rep to the seed file. This method is called during fetchArticles, for each article that is about to be entered into the database. It checks the new article's title and content against the existing articles specific to that Rep. If there's a match, the new article is not saved. 
