### PR TITLE
duplicate articles entered in join table, checks for existing articles using title or excerpt, deletes relation on join table and only deletes article if last relation deleted, and cleanDate cleans non-latin chars

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -178,6 +178,7 @@ end
 # return the date
 def cleanDate(date)
   puts "date: #{date}"
+  date = cleanString(date)
   timeAgo = date.match(/\d+/).to_s.to_i
   hours = (date.index("hours") != nil)
   currentTime = Time.now
@@ -345,5 +346,5 @@ def fetchArticles (start_id = -1)
   end
 end
 
-fetchArticles (-1)
+fetchArticles (65)
 # updateAllReps (378)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -293,8 +293,15 @@ def delete_old_articles(rep, max_article_count = 8)
     count = rep.articles.count
     i = max_article_count
     while i < count
+      # delete ArticlesRep/join table entry
       rep.articles.destroy(articles[i])
-      Article.destroy(articles[i].id)
+
+      # delete Article, only if last Rep pointing to article
+      other_reps_with_articles = ArticlesRep.where(article_id: articles[i].id)
+      if other_reps_with_articles.length == 0
+        Article.destroy(articles[i].id)
+      end
+
       i += 1
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -326,8 +326,19 @@ def fetchArticles (start_id = -1)
         artReturn = Article.create(article)
         if artReturn.id == nil
           # the article already exists in db under a diff rep, needs join table entry for existing article
-          dupId = Article.where(title: article['title'])[0].id
-          ArticlesRep.create(article_id: dupId, rep_id: rep.id)
+
+          # lookup existing article with title, if that fails, use the excerpt
+          if Article.where(title: article['title']).length > 0
+            dupId = Article.where(title: article['title'])[0].id
+            ArticlesRep.create(article_id: dupId, rep_id: rep.id)
+          elsif Article.where(excerpt: article['excerpt']).length > 0
+            dupId = Article.where(excerpt: article['excerpt'])[0].id
+            ArticlesRep.create(article_id: dupId, rep_id: rep.id)
+          else
+            # cannot find the Article using title or excerpt, so cannot link article and rep in join table
+            puts "ERROR CREATING LINK BETWEEN REP AND ARTICLE IN JOIN TABLE"
+          end
+
         else
           # the article does not already exist in the database, needs join table entry for new article
           ArticlesRep.create(article_id: artReturn.id, rep_id: rep.id)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -346,5 +346,5 @@ def fetchArticles (start_id = -1)
   end
 end
 
-fetchArticles (65)
+fetchArticles (-1)
 # updateAllReps (378)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -317,13 +317,12 @@ def fetchArticles (start_id = -1)
 
         artReturn = Article.create(article)
         if artReturn.id == nil
-          # this means that the article already exists in the database
-          # dupId = Article.where(url: article.url)[0].id
-          # ArticlesRep.create(article_id: dupId, rep_id: rep.id)
+          # the article already exists in db under a diff rep, needs join table entry for existing article
+          dupId = Article.where(title: article['title'])[0].id
+          ArticlesRep.create(article_id: dupId, rep_id: rep.id)
         else
-          #   the article does not already exist in the database and it is therefore created
-          ArticlesRep.create(article_id: artReturn.id,
-            rep_id: rep.id)
+          # the article does not already exist in the database, needs join table entry for new article
+          ArticlesRep.create(article_id: artReturn.id, rep_id: rep.id)
         end
 
         index += 1


### PR DESCRIPTION
I reinstated the code I previously commented out (when I added the title and excerpt validations to Article) and made some slight changes to get rid of errors. This code checks for duplicate articles in the database. If found, an entry in ArticlesRep is made between the rep and the found/existing article. If not found, an entry between the rep and the new article is made. This allows for Reps to "share" articles, and utilizes the join table properly.

I added a small if/elsif/else check to the code mentioned above. It checks to make sure we actually found an article by using the title, before treating the response as an array (which, if empty, throws an error and shuts down the seed). If no article is found using the title, we try using the excerpt. If an article is still not found, an error is printed, but not thrown. 

The delete_old_articles method was changed to reflect the proper usage of the join table. When articles are being deleted, only the ArticlesRep relation is deleted. If it's the last ArticlesRep relation to be deleted, then the Article itself is deleted as well. This way, popular Reps won't delete articles of less popular Reps (they'll just delete their own association with the Article).

I fixed the cleanDate method. It was receiving non-latin characters, making it throw an error. It now calls cleanString, gets rid of crazy characters, and doesn't throw an error.
