### PR TITLE
changed current_user method back as twitter login was not working

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,7 +7,7 @@ class ApplicationController < ActionController::Base
   after_filter :cors_set_access_control_headers#, :set_csrf_cookie_for_ng
 
   def current_user
-    if session[:user_id] && User.exists?(:user_id)
+    if session[:user_id] && User.find(session[:user_id])
       @current_user ||= User.find(session[:user_id])
     else
       @current_user = nil


### PR DESCRIPTION
i'm not sure why the current_user method was changed. see this commit for the change: https://github.com/bhhutchens/WeThePAC/commit/2976f3b425f6727160b0b69687811d8302e73e7f

i am changing it back to the original as the twitter login is no longer working and this seems to be the reason. we can fix the error that prompted this change later. :)
